### PR TITLE
[PKG-2337] azure-keyvault-secrets 4.7.0 :snowflake:

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -1,5 +1,0 @@
-upload_channels:
-  - sfe1ed40
-channels:
-  - sfe1ed40
-upload_without_merge: True

--- a/abs.yaml
+++ b/abs.yaml
@@ -2,3 +2,4 @@ upload_channels:
   - sfe1ed40
 channels:
   - sfe1ed40
+upload_without_merge: True

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,0 +1,4 @@
+upload_channels:
+  - sfe1ed40
+channels:
+  - sfe1ed40

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,17 +10,19 @@ source:
   sha256: 77ee2534ba651a1f306c85d7b505bc3ccee8fea77450ebafafc26aec16e5445d
 
 build:
-  noarch: python
   number: 0
-  script: {{ PYTHON }} -m pip install . -vv
+  script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation --ignore-installed --no-cache-dir -vv
+  skip: True  # [py<37]
 
 requirements:
   host:
-    - python >=3.7
+    - python
     - pip
+    - setuptools
+    - wheel
   run:
-    - python >=3.7
-    - azure-common ~=1.1
+    - python
+    - azure-common >=1.1,<1.2
     - azure-core >=1.24.0,<2.0.0
     - isodate >=0.6.1
     - typing-extensions >=4.0.1
@@ -29,15 +31,26 @@ test:
   imports:
     - azure.keyvault.secrets
     - azure.keyvault.secrets.aio
+  requires: 
+    - pip
+  commands: 
+    - pip check
 
 about:
-  home: https://docs.microsoft.com/en-au/azure/key-vault/
+  home: https://learn.microsoft.com/en-au/azure/key-vault/
   license: MIT
   license_family: MIT
   license_file: LICENSE.txt
   summary: Azure Key Vault Secret client library for Python
+  description: |
+    Azure Key Vault Secrets client library for Python.
+    Azure Key Vault helps solve the following problems:
+    - Secrets management (this library) - securely store and control access to tokens, passwords, certificates, API keys, and other secrets
+    - Cryptographic key management (azure-keyvault-keys) - create, store, and control access to the keys used to encrypt your data
+    - Certificate management (azure-keyvault-certificates) - create, manage, and deploy public and private SSL/TLS certificates
+    - Vault administration (azure-keyvault-administration) - role-based access control (RBAC), and vault-level backup and restore options
   doc_url: https://azuresdkdocs.blob.core.windows.net/$web/python/azure-keyvault-secrets/latest/index.html
-  dev_url: https://github.com/Azure/azure-sdk-for-python/tree/master/sdk/keyvault/azure-keyvault-secrets
+  dev_url: https://github.com/Azure/azure-sdk-for-python/tree/main/sdk/keyvault/azure-keyvault-secrets
 
 extra:
   recipe-maintainers:


### PR DESCRIPTION
Changelog: https://github.com/Azure/azure-sdk-for-python/blob/main/sdk/keyvault/azure-keyvault-secrets/CHANGELOG.md
License: https://github.com/Azure/azure-sdk-for-python/blob/main/sdk/keyvault/azure-keyvault-secrets/LICENSE
Requirements: https://github.com/Azure/azure-sdk-for-python/blob/azure-keyvault-secrets_4.7.0/sdk/keyvault/azure-keyvault-secrets/setup.py

Actions:
1. Apply an initial **percy** [patch](https://github.com/anaconda-distribution/percy/blob/main/percy/examples/patch/test_patch.json) and run locally a [script](https://github.com/anaconda-distribution/percy/blob/main/percy/examples/patch/updater_standalone.py) to: 
  - Remove `noarch python`
  - Skip `py<37`
  - Add flags `--no-deps --no-build-isolation` to `script`
  - Add missing `setuptools` and `wheel` to `host`
  - Fix `python` in `host` and `run`
  - Add `pip check`
2. Update `azure-common`s pinning in run
3. Update `home` url
4. Update `dev_url`
5. Add `description`